### PR TITLE
Updated template GHAs to upload HTML doc artifacts for PR review

### DIFF
--- a/idm_standards_plugin/skills/audit-docs/assets/docs_templates/mkdocs_template/.github/workflows/mkdocs-pr.yml
+++ b/idm_standards_plugin/skills/audit-docs/assets/docs_templates/mkdocs_template/.github/workflows/mkdocs-pr.yml
@@ -26,3 +26,10 @@ jobs:
 
     - name: Build MkDocs site
       run: mkdocs build --strict
+
+    - name: Upload built site
+      uses: actions/upload-artifact@v4
+      with:
+        name: mkdocs-site-pr-${{ github.event.pull_request.number }}
+        path: site/
+        retention-days: 14

--- a/idm_standards_plugin/skills/audit-docs/assets/docs_templates/quarto_template/.github/workflows/quarto-ghp.yml
+++ b/idm_standards_plugin/skills/audit-docs/assets/docs_templates/quarto_template/.github/workflows/quarto-ghp.yml
@@ -16,13 +16,15 @@ jobs:
           python-version: 3.x
           cache: 'pip'
 
-      - run: pip install -r requirements.txt
+      - working-directory: docs
+        run: pip install -r requirements.txt
 
       - uses: quarto-dev/quarto-actions/setup@v2
 
       - name: Render and publish
         uses: quarto-dev/quarto-actions/publish@v2
         with:
+          path: docs
           target: gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/idm_standards_plugin/skills/audit-docs/assets/docs_templates/quarto_template/.github/workflows/quarto-pr.yml
+++ b/idm_standards_plugin/skills/audit-docs/assets/docs_templates/quarto_template/.github/workflows/quarto-pr.yml
@@ -19,10 +19,19 @@ jobs:
         cache: 'pip'
 
     - name: Install Python dependencies
+      working-directory: docs
       run: pip install -r requirements.txt
 
     - name: Set up Quarto
       uses: quarto-dev/quarto-actions/setup@v2
 
     - name: Build Quarto site
+      working-directory: docs
       run: quarto render
+
+    - name: Upload built site
+      uses: actions/upload-artifact@v4
+      with:
+        name: quarto-site-pr-${{ github.event.pull_request.number }}
+        path: docs/_site/
+        retention-days: 14


### PR DESCRIPTION
This doesn't host the artifacts, but does provide a means to view the build by downloading the HTML artifacts from GitHub. With MkDocs, we use directory URLs, so navigating the HTML when it isn't hosted feels a bit clunky but is workable to review PRs. This is a much simpler implementation than one that involves hosting the artifacts using only GitHub infrastructure and accommodating private/public repos, forks/branches, etc. 